### PR TITLE
Refactor mcp to unified sql package

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,6 +14,7 @@
     "./torrent": "./src/torrent/index.ts",
     "./aports": "./src/aports/index.ts",
     "./ai/cv": "./src/ai/cv/index.ts",
+    "./mcp": "./src/mcp/index.ts",
     "./package.json": "./package.json",
     "./gen/*": "./src/gen/*.js"
   },
@@ -30,6 +31,8 @@
   "dependencies": {
     "@mikro-orm/better-sqlite": "^6.4.2",
     "@mikro-orm/core": "^6.4.2",
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@orpc/contract": "^0.1.0",
     "@sinclair/typebox": "^0.34.13",
     "@types/json-schema": "^7.0.15",
     "@wener/common": "workspace:^1.0.2",
@@ -45,7 +48,7 @@
     "semver": "^7.6.3",
     "tar": "^7.4.3",
     "ts-pattern": "^5.6.0",
-    "zod": "^3.24.1",
+    "zod": "^4.0.0",
     "zx": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/common/src/mcp/getToolDefinitionsFromContract.ts
+++ b/packages/common/src/mcp/getToolDefinitionsFromContract.ts
@@ -1,0 +1,103 @@
+import {
+	type CallToolRequest,
+	type CallToolResult,
+	type ListResourcesRequest,
+	type ListResourcesResult,
+	type ListToolsRequest,
+	type ListToolsResult,
+	type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Implementer } from '@orpc/server';
+import type { JsonSchemaDef } from '@wener/common/jsonschema';
+import { snakeCase } from 'es-toolkit';
+import { z } from 'zod/v4';
+
+export const McpMetaKey = {
+	tool: 'McpTool',
+} as const;
+
+export function getToolDefinitionsFromContract(
+	contract: Record<string, any>,
+	{ prefix }: { prefix?: string } = {},
+): Tool[] {
+	return Object.entries(contract).flatMap(([k, v]) => {
+		const tm = (v['~orpc'].meta as any)[McpMetaKey.tool] as ToolMeta;
+
+		if (!tm) {
+			return [];
+		}
+
+		let name = tm.name || snakeCase(k);
+		if (prefix) {
+			name = `${prefix}_${name}`;
+		}
+		let description = tm.description || (v['~orpc'].route as any).description || '';
+		let inputSchema = v['~orpc'].inputSchema as z.ZodTypeAny;
+		let outputSchema = v['~orpc'].outputSchema as z.ZodTypeAny;
+		const tool: Tool = {
+			...tm,
+			name,
+			description,
+			inputSchema: z.toJSONSchema(inputSchema) as JsonSchemaDef & { type: 'object' },
+			outputSchema: outputSchema ? (z.toJSONSchema(outputSchema) as JsonSchemaDef & { type: 'object' }) : undefined,
+		};
+		return [tool];
+	});
+}
+
+type ToolMeta = {
+	name?: string;
+	description?: string;
+};
+
+export function createMcpServerHandler<C extends Record<string, any>>(
+	contract: C,
+	impl: Partial<Implementer<C, any, any>>,
+	{ prefix }: { prefix?: string } = {},
+) {
+	const tools: Tool[] = [];
+	const byToolName = new Map<string, string>();
+	for (const [k, v] of Object.entries(contract)) {
+		const tm = (v['~orpc'].meta as any)[McpMetaKey.tool] as ToolMeta;
+
+		if (!tm) {
+			continue;
+		}
+
+		let name = tm.name || snakeCase(k);
+		if (prefix) {
+			name = `${prefix}_${name}`;
+		}
+		let description = tm.description || (v['~orpc'].route as any).description || '';
+		let inputSchema = v['~orpc'].inputSchema as z.ZodTypeAny;
+		const tool: Tool = {
+			...tm,
+			name,
+			description,
+			inputSchema: z.toJSONSchema(inputSchema) as JsonSchemaDef & { type: 'object' },
+		};
+		tools.push(tool);
+		byToolName.set(tool.name, k);
+	}
+
+	return {
+		tools,
+		listTool: async (req: ListToolsRequest): Promise<ListToolsResult> => {
+			return { tools };
+		},
+		listResources: async (req: ListResourcesRequest): Promise<ListResourcesResult> => {
+			return { resources: [] };
+		},
+		callTool: async (req: CallToolRequest): Promise<CallToolResult> => {
+			let fn = byToolName.get(req.method);
+			let f = fn ? (impl as any)[fn] : undefined;
+			if (!fn || !Object.hasOwn(impl, fn) || typeof f !== 'function') {
+				return {
+					content: [{ type: 'text', text: `Tool not found: ${req.method}` }],
+					isError: true,
+				};
+			}
+			return await f(req.params);
+		},
+	};
+}

--- a/packages/common/src/mcp/index.ts
+++ b/packages/common/src/mcp/index.ts
@@ -1,0 +1,2 @@
+export * from './getToolDefinitionsFromContract';
+export * from './sql/SqlServiceContract';

--- a/packages/common/src/mcp/sql/SqlServiceContract.ts
+++ b/packages/common/src/mcp/sql/SqlServiceContract.ts
@@ -1,0 +1,286 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { oc } from '@orpc/contract';
+import { z } from 'zod/v4';
+import { McpMetaKey } from '../getToolDefinitionsFromContract';
+
+/**
+ * SQL Tools ORPC Contract
+ * Defines the interface for SQL execution tools in MCP servers
+ */
+
+const SQLInputSchema = z.object({
+	query: z.string().min(1).describe('The SQL to execute'),
+});
+
+// Input schemas
+export const SQLQueryInputSchema = z.object({
+	query: z.string().min(1).describe('The SQL query to execute'),
+});
+
+export const SQLDMLInputSchema = z.object({
+	query: z.string().min(1).describe('The DML SQL query to execute (INSERT, UPDATE, DELETE, MERGE, REPLACE)'),
+});
+
+export const SqlDdlInputSchema = z.object({
+	query: z.string().min(1).describe('The DDL SQL query to execute (CREATE, ALTER, DROP, TRUNCATE)'),
+});
+
+export const GetVersionInputSchema = z.object({});
+
+// Output schemas
+export const SQLQueryOutputSchema = z.object({
+	content: z.array(
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+		}),
+	),
+});
+
+export const SqlDmlOutputSchema = z.object({
+	content: z.array(
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+		}),
+	),
+});
+
+export const SqlDdlOutputSchema = z.object({
+	content: z.array(
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+		}),
+	),
+});
+
+export const GetVersionOutputSchema = z.object({
+	content: z.array(
+		z.object({
+			type: z.literal('text'),
+			text: z.string(),
+		}),
+	),
+});
+
+// Resource schemas
+export const SqlResourceSchema = z.object({
+	uri: z.string().describe('Resource URI (e.g., mysql://table_name/data)'),
+	name: z.string().describe('Human-readable resource name'),
+	mimeType: z.string().default('text/plain'),
+	description: z.string().describe('Resource description'),
+});
+
+export const ListResourcesOutputSchema = z.object({
+	resources: z.array(SqlResourceSchema),
+});
+
+export const ReadResourceInputSchema = z.object({
+	uri: z.string().describe('Resource URI to read'),
+});
+
+export const ReadResourceOutputSchema = z.object({
+	contents: z.array(
+		z.object({
+			uri: z.string(),
+			mimeType: z.string(),
+			text: z.string(),
+		}),
+	),
+});
+
+// New schemas for listObject and describeObject
+export const ListObjectsInputSchema = z.object({
+	schema: z.string().optional().describe('Schema name to list objects from'),
+});
+
+export const ListObjectsOutputSchema = z.object({
+	objects: z.array(
+		z.object({
+			name: z.string().describe('Object name'),
+			type: z.string().describe('Object type (table, view, index, etc.)'),
+			schema: z.string().optional().describe('Schema name'),
+			description: z.string().optional().describe('Object description'),
+		}),
+	),
+});
+
+export const DescribeObjectInputSchema = z.object({
+	object: z.string().describe('Object name to describe'),
+	schema: z.string().optional().describe('Schema name'),
+});
+
+export const DescribeObjectOutputSchema = z.object({
+	object: z.string().describe('Object name'),
+	type: z.string().describe('Object type'),
+	schema: z.string().optional().describe('Schema name'),
+	columns: z.array(
+		z.object({
+			name: z.string().describe('Column name'),
+			type: z.string().describe('Column data type'),
+			nullable: z.boolean().describe('Whether column allows NULL'),
+			default: z.string().optional().describe('Default value'),
+			key: z.string().optional().describe('Key type (PRI, UNI, MUL)'),
+			extra: z.string().optional().describe('Additional column information'),
+		}),
+	).optional(),
+	indexes: z.array(
+		z.object({
+			name: z.string().describe('Index name'),
+			columns: z.array(z.string()).describe('Column names in index'),
+			unique: z.boolean().describe('Whether index is unique'),
+			type: z.string().optional().describe('Index type'),
+		}),
+	).optional(),
+	description: z.string().optional().describe('Object description'),
+});
+
+export const SqlServiceContract = {
+	queryCsv: oc
+		.input(SQLInputSchema)
+		.output(CallToolResultSchema)
+		// .output(
+		// 	z.object({
+		// 		format: z.literal('csv').default('csv'),
+		// 		csv: z.string(),
+		// 		message: z.string().optional(),
+		// 		total: z.number().optional().describe('Total number of rows returned'),
+		// 	}),
+		// )
+		.route({
+			description: 'Execute read-only SQL queries and return results in CSV format',
+			tags: ['sql', 'read-only', 'csv'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	queryJson: oc
+		.input(SQLInputSchema)
+		.output(CallToolResultSchema)
+		// .output(
+		// 	z.object({
+		// 		format: z.literal('json').default('json'),
+		// 		rows: z.record(z.string(), z.any()).array().default([]),
+		// 		message: z.string().optional(),
+		// 		total: z.number().optional().describe('Total number of rows returned'),
+		// 	}),
+		// )
+		.route({
+			description: 'Execute read-only SQL queries and return results in JSON format',
+			tags: ['sql', 'read-only', 'json'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	// General SQL execution tool
+	executeSql: oc
+		.input(SQLInputSchema)
+		.output(
+			z.object({
+				rows: z.record(z.string(), z.any()).array().default([]),
+				message: z.string().optional(),
+				total: z.number().optional().describe('Total number of rows affected or returned'),
+				affectedRows: z.number().optional().describe('Number of rows affected (for write operations)'),
+			}),
+		)
+		.route({
+			description: 'Execute any SQL operation (requires readwrite mode for write operations)',
+			tags: ['sql', 'any-operation', 'json'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	// DML (Data Manipulation Language) tool
+	executeDml: oc
+		.input(SQLInputSchema)
+		.output(
+			z.object({
+				message: z.string().optional(),
+				affectedRows: z.number().optional().describe('Number of rows affected (for write operations)'),
+			}),
+		)
+		.route({
+			description: 'Execute DML operations (INSERT, UPDATE, DELETE, MERGE, REPLACE)',
+			tags: ['sql', 'dml', 'write'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	// DDL (Data Definition Language) tool
+	executeDdl: oc
+		.input(SQLInputSchema)
+		.output(
+			z.object({
+				message: z.string().optional(),
+			}),
+		)
+		.route({
+			description: 'Execute DDL operations (CREATE, ALTER, DROP, TRUNCATE)',
+			tags: ['sql', 'ddl', 'schema'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	// Version information tool
+	getVersion: oc
+		.input(z.object({}))
+		.output(
+			z.object({
+				version: z.string().describe('Database server version string'),
+				type: z.string().describe('Database type (e.g., PostgreSQL, MySQL, etc.)'),
+			}),
+		)
+		.route({
+			description: 'Get database server version information',
+			tags: ['sql', 'info', 'version'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	// Resource management
+	listResources: oc
+		.input(z.object({}))
+		.output(ListResourcesOutputSchema)
+		.route({
+			description: 'List available database resources (tables, views, etc.)',
+			tags: ['sql', 'resources', 'list'],
+		}),
+
+	readResource: oc
+		.input(ReadResourceInputSchema)
+		.output(ReadResourceOutputSchema)
+		.route({
+			description: 'Read data from a specific database resource',
+			tags: ['sql', 'resources', 'read'],
+		}),
+
+	// New object management tools
+	listObjects: oc
+		.input(ListObjectsInputSchema)
+		.output(ListObjectsOutputSchema)
+		.route({
+			description: 'List database objects (tables, views, indexes, etc.)',
+			tags: ['sql', 'objects', 'list'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+
+	describeObject: oc
+		.input(DescribeObjectInputSchema)
+		.output(DescribeObjectOutputSchema)
+		.route({
+			description: 'Describe a specific database object structure',
+			tags: ['sql', 'objects', 'describe'],
+		})
+		.meta({
+			[McpMetaKey.tool]: {},
+		}),
+};

--- a/packages/wener-sql-mcp/README.md
+++ b/packages/wener-sql-mcp/README.md
@@ -1,0 +1,37 @@
+# @wener/sql-mcp
+
+Unified SQL MCP server supporting multiple database backends via Knex.
+
+## Features
+
+- Support for MySQL, PostgreSQL, SQLite, and other Knex-compatible databases
+- Unified SQL interface through MCP protocol
+- Resource management for database objects
+- Type-safe contracts using ORPC and Zod
+
+## Usage
+
+```typescript
+import { createKnexSqlServiceImpl } from '@wener/sql-mcp';
+import { createMcpServerHandler } from '@wener/sql-mcp';
+
+const knex = require('knex')({
+  client: 'mysql2',
+  connection: {
+    host: 'localhost',
+    user: 'root',
+    password: 'password',
+    database: 'mydb'
+  }
+});
+
+const service = createKnexSqlServiceImpl(knex);
+const handler = createMcpServerHandler(service);
+```
+
+## Supported Databases
+
+- MySQL (via mysql2)
+- PostgreSQL (via pg)
+- SQLite (via sqlite3)
+- Any other Knex-compatible database

--- a/packages/wener-sql-mcp/package.json
+++ b/packages/wener-sql-mcp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@wener/sql-mcp",
+  "version": "0.1.0",
+  "description": "Unified SQL MCP server supporting multiple database backends via Knex",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@orpc/contract": "^0.1.0",
+    "@wener/common": "file:../common",
+    "knex": "^3.1.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "peerDependencies": {
+    "mysql2": "*",
+    "pg": "*",
+    "sqlite3": "*"
+  },
+  "keywords": [
+    "mcp",
+    "sql",
+    "database",
+    "knex",
+    "mysql",
+    "postgresql",
+    "sqlite"
+  ],
+  "author": "Wener",
+  "license": "MIT"
+}

--- a/packages/wener-sql-mcp/src/createKnexSqlServiceImpl.test.ts
+++ b/packages/wener-sql-mcp/src/createKnexSqlServiceImpl.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnexSqlServiceImpl } from './createKnexSqlServiceImpl';
+
+// Mock Knex
+const mockKnex = {
+	raw: vi.fn(),
+	client: {
+		config: {
+			client: 'mysql2'
+		}
+	}
+} as any;
+
+describe('createKnexSqlServiceImpl', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should create service implementation', () => {
+		const service = createKnexSqlServiceImpl(mockKnex);
+		
+		expect(service).toBeDefined();
+		expect(service.queryCsv).toBeDefined();
+		expect(service.queryJson).toBeDefined();
+		expect(service.executeSql).toBeDefined();
+		expect(service.executeDml).toBeDefined();
+		expect(service.executeDdl).toBeDefined();
+		expect(service.getVersion).toBeDefined();
+		expect(service.listObjects).toBeDefined();
+		expect(service.describeObject).toBeDefined();
+	});
+
+	it('should handle queryCsv', async () => {
+		const mockRows = [
+			{ id: 1, name: 'test' },
+			{ id: 2, name: 'test2' }
+		];
+		mockKnex.raw.mockResolvedValue(mockRows);
+
+		const service = createKnexSqlServiceImpl(mockKnex);
+		const result = await service.queryCsv!({ query: 'SELECT * FROM test' });
+
+		expect(result).toEqual({
+			content: [{
+				type: 'text',
+				text: 'id,name\n1,test\n2,test2'
+			}]
+		});
+	});
+
+	it('should handle queryJson', async () => {
+		const mockRows = [
+			{ id: 1, name: 'test' },
+			{ id: 2, name: 'test2' }
+		];
+		mockKnex.raw.mockResolvedValue(mockRows);
+
+		const service = createKnexSqlServiceImpl(mockKnex);
+		const result = await service.queryJson!({ query: 'SELECT * FROM test' });
+
+		expect(result).toEqual({
+			content: [{
+				type: 'text',
+				text: JSON.stringify(mockRows, null, 2)
+			}]
+		});
+	});
+
+	it('should handle getVersion', async () => {
+		mockKnex.raw.mockResolvedValue([{ version: '8.0.0' }]);
+
+		const service = createKnexSqlServiceImpl(mockKnex);
+		const result = await service.getVersion!();
+
+		expect(result).toEqual({
+			version: '8.0.0',
+			type: 'MySQL'
+		});
+	});
+
+	it('should respect read-only mode', async () => {
+		const service = createKnexSqlServiceImpl(mockKnex, { readOnly: true });
+
+		await expect(service.executeDml!({ query: 'INSERT INTO test VALUES (1)' }))
+			.rejects.toThrow('DML operations are not allowed in read-only mode');
+
+		await expect(service.executeDdl!({ query: 'CREATE TABLE test (id INT)' }))
+			.rejects.toThrow('DDL operations are not allowed in read-only mode');
+	});
+
+	it('should handle maxRows limit', async () => {
+		const mockRows = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+		mockKnex.raw.mockResolvedValue(mockRows);
+
+		const service = createKnexSqlServiceImpl(mockKnex, { maxRows: 5 });
+		const result = await service.executeSql!({ query: 'SELECT * FROM test' });
+
+		expect(result.rows).toHaveLength(5);
+		expect(result.total).toBe(10);
+	});
+});

--- a/packages/wener-sql-mcp/src/createKnexSqlServiceImpl.ts
+++ b/packages/wener-sql-mcp/src/createKnexSqlServiceImpl.ts
@@ -1,0 +1,452 @@
+import type { Knex } from 'knex';
+import { SqlServiceContract } from '@wener/common/mcp/sql/SqlServiceContract';
+import type { Implementer } from '@orpc/server';
+
+export interface KnexSqlServiceConfig {
+	/**
+	 * Maximum number of rows to return in queries (default: 1000)
+	 */
+	maxRows?: number;
+	/**
+	 * Whether to enable read-only mode (default: false)
+	 */
+	readOnly?: boolean;
+	/**
+	 * Custom error handler
+	 */
+	onError?: (error: Error, context: string) => void;
+}
+
+export function createKnexSqlServiceImpl(
+	knex: Knex,
+	config: KnexSqlServiceConfig = {}
+): Partial<Implementer<typeof SqlServiceContract, any, any>> {
+	const { maxRows = 1000, readOnly = false, onError } = config;
+
+	const handleError = (error: Error, context: string) => {
+		if (onError) {
+			onError(error, context);
+		}
+		console.error(`SQL Error in ${context}:`, error);
+		throw error;
+	};
+
+	const formatRowsAsCsv = (rows: any[]): string => {
+		if (rows.length === 0) return '';
+		
+		const headers = Object.keys(rows[0]);
+		const csvRows = rows.map(row => 
+			headers.map(header => {
+				const value = row[header];
+				if (value === null || value === undefined) return '';
+				const str = String(value);
+				// Escape quotes and wrap in quotes if contains comma, quote, or newline
+				if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+					return `"${str.replace(/"/g, '""')}"`;
+				}
+				return str;
+			}).join(',')
+		);
+		
+		return [headers.join(','), ...csvRows].join('\n');
+	};
+
+	const formatRowsAsJson = (rows: any[]): any[] => {
+		return rows.map(row => {
+			const result: any = {};
+			for (const [key, value] of Object.entries(row)) {
+				// Convert dates to ISO strings
+				if (value instanceof Date) {
+					result[key] = value.toISOString();
+				} else {
+					result[key] = value;
+				}
+			}
+			return result;
+		});
+	};
+
+	const executeQuery = async (query: string, limit?: number) => {
+		try {
+			let builder = knex.raw(query);
+			
+			if (limit && limit > 0) {
+				// For raw queries, we need to add LIMIT manually
+				// This is a simplified approach - in practice, you might want to parse the SQL
+				if (!query.toLowerCase().includes('limit')) {
+					builder = knex.raw(`${query} LIMIT ${limit}`);
+				}
+			}
+
+			const result = await builder;
+			
+			// Handle different result formats based on database type
+			if (Array.isArray(result)) {
+				// PostgreSQL returns array of rows
+				return {
+					rows: result.slice(0, limit || maxRows),
+					total: result.length,
+					affectedRows: result.length
+				};
+			} else if (result.rows) {
+				// Some databases return { rows: [...] }
+				return {
+					rows: result.rows.slice(0, limit || maxRows),
+					total: result.rows.length,
+					affectedRows: result.rows.length
+				};
+			} else if (result[0]) {
+				// MySQL returns array of arrays
+				const rows = Array.isArray(result[0]) ? result[0] : [result[0]];
+				return {
+					rows: rows.slice(0, limit || maxRows),
+					total: rows.length,
+					affectedRows: rows.length
+				};
+			} else {
+				return {
+					rows: [],
+					total: 0,
+					affectedRows: 0
+				};
+			}
+		} catch (error) {
+			handleError(error as Error, 'executeQuery');
+		}
+	};
+
+	const getDatabaseInfo = async () => {
+		try {
+			const client = knex.client.config.client;
+			let versionQuery = '';
+			let type = '';
+
+			switch (client) {
+				case 'mysql':
+				case 'mysql2':
+					versionQuery = 'SELECT VERSION() as version';
+					type = 'MySQL';
+					break;
+				case 'pg':
+					versionQuery = 'SELECT version() as version';
+					type = 'PostgreSQL';
+					break;
+				case 'sqlite3':
+					versionQuery = 'SELECT sqlite_version() as version';
+					type = 'SQLite';
+					break;
+				default:
+					versionQuery = 'SELECT 1 as version';
+					type = 'Unknown';
+			}
+
+			const result = await knex.raw(versionQuery);
+			const version = Array.isArray(result) ? result[0]?.version : result.rows?.[0]?.version || 'Unknown';
+			
+			return { version, type };
+		} catch (error) {
+			handleError(error as Error, 'getDatabaseInfo');
+		}
+	};
+
+	const listDatabaseObjects = async (schema?: string) => {
+		try {
+			const client = knex.client.config.client;
+			let query = '';
+
+			switch (client) {
+				case 'mysql':
+				case 'mysql2':
+					query = `
+						SELECT 
+							TABLE_NAME as name,
+							TABLE_TYPE as type,
+							TABLE_SCHEMA as schema,
+							TABLE_COMMENT as description
+						FROM information_schema.TABLES 
+						WHERE TABLE_SCHEMA = ? OR ? IS NULL
+						ORDER BY TABLE_TYPE, TABLE_NAME
+					`;
+					break;
+				case 'pg':
+					query = `
+						SELECT 
+							tablename as name,
+							CASE 
+								WHEN schemaname = 'pg_catalog' THEN 'system table'
+								WHEN schemaname = 'information_schema' THEN 'system view'
+								ELSE 'table'
+							END as type,
+							schemaname as schema,
+							obj_description(c.oid) as description
+						FROM pg_tables t
+						LEFT JOIN pg_class c ON c.relname = t.tablename
+						WHERE schemaname = ? OR ? IS NULL
+						UNION ALL
+						SELECT 
+							viewname as name,
+							'view' as type,
+							schemaname as schema,
+							obj_description(c.oid) as description
+						FROM pg_views v
+						LEFT JOIN pg_class c ON c.relname = v.viewname
+						WHERE schemaname = ? OR ? IS NULL
+						ORDER BY type, name
+					`;
+					break;
+				case 'sqlite3':
+					query = `
+						SELECT 
+							name,
+							type,
+							'sqlite' as schema,
+							NULL as description
+						FROM sqlite_master 
+						WHERE type IN ('table', 'view', 'index')
+						ORDER BY type, name
+					`;
+					break;
+				default:
+					return { objects: [] };
+			}
+
+			const result = await knex.raw(query, schema ? [schema, schema, schema, schema] : [null, null, null, null]);
+			const rows = Array.isArray(result) ? result : result.rows || [];
+			
+			return {
+				objects: rows.map((row: any) => ({
+					name: row.name,
+					type: row.type,
+					schema: row.schema,
+					description: row.description || undefined
+				}))
+			};
+		} catch (error) {
+			handleError(error as Error, 'listDatabaseObjects');
+		}
+	};
+
+	const describeDatabaseObject = async (object: string, schema?: string) => {
+		try {
+			const client = knex.client.config.client;
+			let query = '';
+			let columnQuery = '';
+			let indexQuery = '';
+
+			switch (client) {
+				case 'mysql':
+				case 'mysql2':
+					columnQuery = `
+						SELECT 
+							COLUMN_NAME as name,
+							DATA_TYPE as type,
+							IS_NULLABLE = 'YES' as nullable,
+							COLUMN_DEFAULT as default,
+							COLUMN_KEY as key,
+							EXTRA as extra
+						FROM information_schema.COLUMNS 
+						WHERE TABLE_NAME = ? AND (TABLE_SCHEMA = ? OR ? IS NULL)
+						ORDER BY ORDINAL_POSITION
+					`;
+					indexQuery = `
+						SELECT 
+							INDEX_NAME as name,
+							GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) as columns,
+							NON_UNIQUE = 0 as unique,
+							INDEX_TYPE as type
+						FROM information_schema.STATISTICS 
+						WHERE TABLE_NAME = ? AND (TABLE_SCHEMA = ? OR ? IS NULL)
+						GROUP BY INDEX_NAME, NON_UNIQUE, INDEX_TYPE
+						ORDER BY INDEX_NAME
+					`;
+					break;
+				case 'pg':
+					columnQuery = `
+						SELECT 
+							column_name as name,
+							data_type as type,
+							is_nullable = 'YES' as nullable,
+							column_default as default,
+							CASE 
+								WHEN pk.column_name IS NOT NULL THEN 'PRI'
+								WHEN uk.column_name IS NOT NULL THEN 'UNI'
+								WHEN fk.column_name IS NOT NULL THEN 'MUL'
+							END as key,
+							NULL as extra
+						FROM information_schema.columns c
+						LEFT JOIN (
+							SELECT ku.column_name
+							FROM information_schema.table_constraints tc
+							JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name
+							WHERE tc.constraint_type = 'PRIMARY KEY' AND tc.table_name = ?
+						) pk ON c.column_name = pk.column_name
+						LEFT JOIN (
+							SELECT ku.column_name
+							FROM information_schema.table_constraints tc
+							JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name
+							WHERE tc.constraint_type = 'UNIQUE' AND tc.table_name = ?
+						) uk ON c.column_name = uk.column_name
+						LEFT JOIN (
+							SELECT ku.column_name
+							FROM information_schema.table_constraints tc
+							JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name
+							WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = ?
+						) fk ON c.column_name = fk.column_name
+						WHERE c.table_name = ? AND (c.table_schema = ? OR ? IS NULL)
+						ORDER BY c.ordinal_position
+					`;
+					indexQuery = `
+						SELECT 
+							indexname as name,
+							array_to_string(array_agg(attname ORDER BY attnum), ',') as columns,
+							NOT indisunique as unique,
+							indexdef as type
+						FROM pg_index i
+						JOIN pg_class c ON c.oid = i.indexrelid
+						JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+						WHERE i.indrelid = (
+							SELECT oid FROM pg_class WHERE relname = ? AND (relnamespace = (
+								SELECT oid FROM pg_namespace WHERE nspname = ? OR ? IS NULL
+							))
+						)
+						GROUP BY indexname, indisunique, indexdef
+						ORDER BY indexname
+					`;
+					break;
+				case 'sqlite3':
+					columnQuery = `
+						PRAGMA table_info(?)
+					`;
+					indexQuery = `
+						PRAGMA index_list(?)
+					`;
+					break;
+				default:
+					return {
+						object,
+						type: 'unknown',
+						schema,
+						description: 'Unknown database type'
+					};
+			}
+
+			// Get columns
+			const columnResult = await knex.raw(columnQuery, 
+				client === 'sqlite3' ? [object] : 
+				client === 'pg' ? [object, object, object, object, schema, schema] :
+				[object, schema, schema]
+			);
+			const columns = Array.isArray(columnResult) ? columnResult : columnResult.rows || [];
+
+			// Get indexes
+			const indexResult = await knex.raw(indexQuery, 
+				client === 'sqlite3' ? [object] :
+				client === 'pg' ? [object, schema, schema] :
+				[object, schema, schema]
+			);
+			const indexes = Array.isArray(indexResult) ? indexResult : indexResult.rows || [];
+
+			// Get object type
+			const typeResult = await knex.raw(`
+				SELECT 
+					CASE 
+						WHEN type = 'table' THEN 'table'
+						WHEN type = 'view' THEN 'view'
+						ELSE type
+					END as type
+				FROM sqlite_master 
+				WHERE name = ?
+			`, [object]);
+
+			const objectType = Array.isArray(typeResult) ? typeResult[0]?.type : typeResult.rows?.[0]?.type || 'table';
+
+			return {
+				object,
+				type: objectType,
+				schema,
+				columns: columns.map((col: any) => ({
+					name: col.name,
+					type: col.type,
+					nullable: col.nullable,
+					default: col.default,
+					key: col.key,
+					extra: col.extra
+				})),
+				indexes: indexes.map((idx: any) => ({
+					name: idx.name,
+					columns: idx.columns.split(',').map((c: string) => c.trim()),
+					unique: idx.unique,
+					type: idx.type
+				}))
+			};
+		} catch (error) {
+			handleError(error as Error, 'describeDatabaseObject');
+		}
+	};
+
+	return {
+		queryCsv: async ({ query }) => {
+			const result = await executeQuery(query);
+			const csv = formatRowsAsCsv(result.rows);
+			return {
+				content: [{ type: 'text' as const, text: csv }]
+			};
+		},
+
+		queryJson: async ({ query }) => {
+			const result = await executeQuery(query);
+			const json = formatRowsAsJson(result.rows);
+			return {
+				content: [{ type: 'text' as const, text: JSON.stringify(json, null, 2) }]
+			};
+		},
+
+		executeSql: async ({ query }) => {
+			if (readOnly && /^\s*(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|MERGE|REPLACE)/i.test(query)) {
+				throw new Error('Write operations are not allowed in read-only mode');
+			}
+			
+			const result = await executeQuery(query);
+			return {
+				rows: formatRowsAsJson(result.rows),
+				total: result.total,
+				affectedRows: result.affectedRows
+			};
+		},
+
+		executeDml: async ({ query }) => {
+			if (readOnly) {
+				throw new Error('DML operations are not allowed in read-only mode');
+			}
+			
+			const result = await executeQuery(query);
+			return {
+				message: `Operation completed successfully`,
+				affectedRows: result.affectedRows
+			};
+		},
+
+		executeDdl: async ({ query }) => {
+			if (readOnly) {
+				throw new Error('DDL operations are not allowed in read-only mode');
+			}
+			
+			await executeQuery(query);
+			return {
+				message: `DDL operation completed successfully`
+			};
+		},
+
+		getVersion: async () => {
+			return await getDatabaseInfo();
+		},
+
+		listObjects: async ({ schema }) => {
+			return await listDatabaseObjects(schema);
+		},
+
+		describeObject: async ({ object, schema }) => {
+			return await describeDatabaseObject(object, schema);
+		}
+	};
+}

--- a/packages/wener-sql-mcp/src/createMcpServerHandler.ts
+++ b/packages/wener-sql-mcp/src/createMcpServerHandler.ts
@@ -1,0 +1,150 @@
+import type { Knex } from 'knex';
+import {
+	type CallToolRequest,
+	type CallToolResult,
+	type ListResourcesRequest,
+	type ListResourcesResult,
+	type ListToolsRequest,
+	type ListToolsResult,
+	type Resource,
+	type ReadResourceRequest,
+	type ReadResourceResult,
+} from '@modelcontextprotocol/sdk/types.js';
+import { SqlServiceContract } from '@wener/common/mcp/sql/SqlServiceContract';
+import { createMcpServerHandler as createBaseHandler } from '@wener/common/mcp/getToolDefinitionsFromContract';
+import { createKnexSqlServiceImpl, type KnexSqlServiceConfig } from './createKnexSqlServiceImpl';
+
+export interface McpSqlServerConfig extends KnexSqlServiceConfig {
+	/**
+	 * Database connection name for resource URIs
+	 */
+	databaseName?: string;
+	/**
+	 * Whether to include database objects as resources
+	 */
+	includeObjectsAsResources?: boolean;
+}
+
+export function createMcpServerHandler(
+	knex: Knex,
+	config: McpSqlServerConfig = {}
+) {
+	const {
+		databaseName = 'database',
+		includeObjectsAsResources = true,
+		...serviceConfig
+	} = config;
+
+	const service = createKnexSqlServiceImpl(knex, serviceConfig);
+	const baseHandler = createBaseHandler(SqlServiceContract, service);
+
+	// Get database objects for resource listing
+	const getDatabaseObjects = async (): Promise<Resource[]> => {
+		if (!includeObjectsAsResources) {
+			return [];
+		}
+
+		try {
+			const result = await service.listObjects?.({});
+			if (!result?.objects) {
+				return [];
+			}
+
+			return result.objects.map(obj => ({
+				uri: `${knex.client.config.client}://${databaseName}/${obj.schema ? `${obj.schema}.` : ''}${obj.name}`,
+				name: obj.name,
+				mimeType: 'application/sql',
+				description: obj.description || `${obj.type} in ${obj.schema || 'default schema'}`
+			}));
+		} catch (error) {
+			console.error('Error listing database objects:', error);
+			return [];
+		}
+	};
+
+	// Read resource content
+	const readResourceContent = async (uri: string): Promise<ReadResourceResult> => {
+		try {
+			// Parse URI: client://database/schema.object or client://database/object
+			const uriMatch = uri.match(/^(\w+):\/\/([^\/]+)\/(.+)$/);
+			if (!uriMatch) {
+				throw new Error(`Invalid resource URI format: ${uri}`);
+			}
+
+			const [, client, db, objectPath] = uriMatch;
+			const [schema, object] = objectPath.includes('.') ? objectPath.split('.') : [undefined, objectPath];
+
+			// Get object description
+			const describeResult = await service.describeObject?.({ object, schema });
+			if (!describeResult) {
+				throw new Error(`Object not found: ${objectPath}`);
+			}
+
+			// Format the description as SQL DDL
+			let content = `-- ${describeResult.type.toUpperCase()}: ${objectPath}\n`;
+			if (describeResult.schema) {
+				content += `-- Schema: ${describeResult.schema}\n`;
+			}
+			content += `-- Database: ${client}\n\n`;
+
+			if (describeResult.columns && describeResult.columns.length > 0) {
+				content += `-- Columns:\n`;
+				describeResult.columns.forEach(col => {
+					content += `--   ${col.name}: ${col.type}`;
+					if (!col.nullable) content += ` NOT NULL`;
+					if (col.default) content += ` DEFAULT ${col.default}`;
+					if (col.key === 'PRI') content += ` PRIMARY KEY`;
+					if (col.key === 'UNI') content += ` UNIQUE`;
+					if (col.extra) content += ` (${col.extra})`;
+					content += `\n`;
+				});
+				content += `\n`;
+			}
+
+			if (describeResult.indexes && describeResult.indexes.length > 0) {
+				content += `-- Indexes:\n`;
+				describeResult.indexes.forEach(idx => {
+					content += `--   ${idx.name}: ${idx.columns.join(', ')}`;
+					if (idx.unique) content += ` (UNIQUE)`;
+					if (idx.type) content += ` (${idx.type})`;
+					content += `\n`;
+				});
+				content += `\n`;
+			}
+
+			// Add sample query
+			content += `-- Sample query:\n`;
+			content += `SELECT * FROM ${schema ? `${schema}.` : ''}${object} LIMIT 10;\n`;
+
+			return {
+				contents: [{
+					uri,
+					mimeType: 'application/sql',
+					text: content
+				}]
+			};
+		} catch (error) {
+			console.error('Error reading resource:', error);
+			return {
+				contents: [{
+					uri,
+					mimeType: 'text/plain',
+					text: `Error reading resource: ${error instanceof Error ? error.message : 'Unknown error'}`
+				}]
+			};
+		}
+	};
+
+	return {
+		...baseHandler,
+		
+		listResources: async (req: ListResourcesRequest): Promise<ListResourcesResult> => {
+			const objects = await getDatabaseObjects();
+			return { resources: objects };
+		},
+
+		readResource: async (req: ReadResourceRequest): Promise<ReadResourceResult> => {
+			return await readResourceContent(req.uri);
+		}
+	};
+}

--- a/packages/wener-sql-mcp/src/example.ts
+++ b/packages/wener-sql-mcp/src/example.ts
@@ -1,0 +1,82 @@
+import { createMcpServerHandler } from './index';
+import knex from 'knex';
+
+// Example usage with different database types
+
+// MySQL example
+export function createMySQLHandler() {
+	const mysqlKnex = knex({
+		client: 'mysql2',
+		connection: {
+			host: 'localhost',
+			user: 'root',
+			password: 'password',
+			database: 'mydb'
+		}
+	});
+
+	return createMcpServerHandler(mysqlKnex, {
+		databaseName: 'mydb',
+		maxRows: 1000,
+		readOnly: false
+	});
+}
+
+// PostgreSQL example
+export function createPostgreSQLHandler() {
+	const pgKnex = knex({
+		client: 'pg',
+		connection: {
+			host: 'localhost',
+			port: 5432,
+			user: 'postgres',
+			password: 'password',
+			database: 'mydb'
+		}
+	});
+
+	return createMcpServerHandler(pgKnex, {
+		databaseName: 'mydb',
+		maxRows: 1000,
+		readOnly: false
+	});
+}
+
+// SQLite example
+export function createSQLiteHandler() {
+	const sqliteKnex = knex({
+		client: 'sqlite3',
+		connection: {
+			filename: './database.sqlite'
+		}
+	});
+
+	return createMcpServerHandler(sqliteKnex, {
+		databaseName: 'database',
+		maxRows: 1000,
+		readOnly: false
+	});
+}
+
+// Example MCP server setup
+export async function createMcpServer() {
+	// Choose your database handler
+	const handler = createMySQLHandler(); // or createPostgreSQLHandler(), createSQLiteHandler()
+
+	// Example: List available tools
+	const tools = await handler.listTool({});
+	console.log('Available tools:', tools.tools.map(t => t.name));
+
+	// Example: List database resources
+	const resources = await handler.listResources({});
+	console.log('Available resources:', resources.resources.map(r => r.uri));
+
+	// Example: Execute a query
+	const queryResult = await handler.callTool({
+		method: 'queryJson',
+		params: { query: 'SELECT 1 as test' }
+	});
+	console.log('Query result:', queryResult);
+
+	return handler;
+}

--- a/packages/wener-sql-mcp/src/index.ts
+++ b/packages/wener-sql-mcp/src/index.ts
@@ -1,0 +1,7 @@
+export { createKnexSqlServiceImpl } from './createKnexSqlServiceImpl';
+export { createMcpServerHandler } from './createMcpServerHandler';
+export type { KnexSqlServiceConfig } from './createKnexSqlServiceImpl';
+export type { McpSqlServerConfig } from './createMcpServerHandler';
+
+// Re-export the contract for convenience
+export { SqlServiceContract } from '@wener/common/mcp/sql/SqlServiceContract';

--- a/packages/wener-sql-mcp/src/test.ts
+++ b/packages/wener-sql-mcp/src/test.ts
@@ -1,0 +1,22 @@
+// Simple test to verify the implementation compiles
+import { createKnexSqlServiceImpl, createMcpServerHandler } from './index';
+
+// Mock Knex instance for testing
+const mockKnex = {
+	raw: async () => [{ id: 1, name: 'test' }],
+	client: {
+		config: {
+			client: 'mysql2'
+		}
+	}
+} as any;
+
+// Test service creation
+const service = createKnexSqlServiceImpl(mockKnex);
+console.log('Service created successfully:', Object.keys(service));
+
+// Test MCP handler creation
+const handler = createMcpServerHandler(mockKnex);
+console.log('Handler created successfully:', Object.keys(handler));
+
+export { service, handler };

--- a/packages/wener-sql-mcp/tsconfig.json
+++ b/packages/wener-sql-mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}


### PR DESCRIPTION
Refactor MySQL and PostgreSQL MCP packages into a unified `wener-sql-mcp` using Knex.

This consolidates database-specific MCP implementations into a generic Knex-based service, improving maintainability, reusability, and extensibility across various SQL databases. It also introduces `listObject` and `describeObject` to the `SqlServiceContract` for better database introspection capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-144530c2-9494-40c0-bcad-c8d4fb75eb74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-144530c2-9494-40c0-bcad-c8d4fb75eb74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

