### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,8 @@ go.work
     - [Document](https://apis.wener.me/docs/rjsf-antd-theme/)
 
 <!-- LINK:END -->
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wenerme-wener-mssql-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wenerme-wener-mssql-mcp).